### PR TITLE
Support for external evaluation measures (includes Meteor wrapper as example)

### DIFF
--- a/contrib/files/.gitignore
+++ b/contrib/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/contrib/meteor.py
+++ b/contrib/meteor.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# This is an example of an external evaluation measure for Lamtram.  To use
+# Meteor as a training target, specify:
+# --eval_meas extern:eos=false,run=/path/to/lamtram/contrib/meteor.py
+#
+# For external scoring, Lamtram opens the specified "run" executable as a sub-
+# process and sends one output/reference pair at a time to score.  Lamtram sends
+# a line to stdin in the form
+# system output ||| reference translation
+# and reads a line from stdout that should contain a single float for the score.
+
+import os
+import subprocess
+import sys
+
+METEOR_URL = "https://www.cs.cmu.edu/~alavie/METEOR/download/meteor-1.5.tar.gz"
+METEOR_TGZ = "meteor-1.5.tar.gz"
+METEOR_DIR = "meteor-1.5"
+METEOR_JAR = "meteor-1.5.jar"
+
+# To use a different version of Meteor, make a copy of this script in the same
+# directory and change the args line below.  Text from Lamtram is already
+# tokenized, so only apply lower-casing.  Things to try:
+# Different languages: -l <de/es/fr/...>
+# Different tasks: -t <rank/adq/hter>
+# Run `java -jar meteor-1.5.jar` for a full list of options
+
+METEOR_ARGS = "-lower -l en -t tune"
+
+
+def main():
+
+  # Meteor checkout lives in git-ignored files subdir
+  files_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "files")
+  meteor_jar = os.path.join(files_dir, METEOR_DIR, METEOR_JAR)
+
+  # Download Meteor if not present
+  if not os.path.exists(meteor_jar):
+    meteor_tgz = os.path.join(files_dir, METEOR_TGZ)
+    subprocess.call("wget -c -O {} {}".format(meteor_tgz, METEOR_URL),
+                    shell=True)
+    subprocess.call("tar -x -f {} -C {}".format(meteor_tgz, files_dir),
+                    shell=True)
+
+  # Run Meteor in streaming mode
+  meteor = subprocess.Popen(
+      "java -Xmx2G -jar {} - - -stdio {}".format(meteor_jar, METEOR_ARGS),
+      shell=True,
+      stdin=subprocess.PIPE,
+      stdout=subprocess.PIPE)
+
+  # For each line from Lamtram:
+  while True:
+    line = sys.stdin.readline()
+    if not line:
+      break
+    # Parse the line: out ||| ref
+    out, ref = (f.strip() for f in line.split("|||"))
+    # Write to Meteor: SCORE ||| ref ||| out
+    meteor.stdin.write("SCORE ||| {} ||| {}\n".format(ref, out))
+    # Read stats from Meteor
+    stats = meteor.stdout.readline()  # still ends with \n
+    # Write to Meteor: EVAL ||| stats
+    meteor.stdin.write("EVAL ||| {}".format(stats))
+    # Read score from Meteor
+    score = meteor.stdout.readline()  # still ends with \n
+    # Write score to Lamtram
+    sys.stdout.write(score)
+    # Must flush after every line to avoid process communication deadlock
+    sys.stdout.flush()
+
+  # Cleanup
+  meteor.stdin.close()
+  meteor.wait()
+
+
+if __name__ == "__main__":
+  main()

--- a/src/lamtram/Makefile.am
+++ b/src/lamtram/Makefile.am
@@ -34,6 +34,7 @@ LIBCPP = \
     dist-unk.cc \
     eval-measure-loader.cc \
     eval-measure-bleu.cc \
+    eval-measure-extern.cc \
     eval-measure-ribes.cc \
     eval-measure-wer.cc \
     eval-measure-interp.cc \

--- a/src/lamtram/eval-measure-extern.cc
+++ b/src/lamtram/eval-measure-extern.cc
@@ -1,0 +1,101 @@
+#include <lamtram/eval-measure-extern.h>
+#include <lamtram/macros.h>
+#include <cnn/dict.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/lexical_cast.hpp>
+
+// External scoring code is adapted from Moses, which is also LGPL 2.1:
+// github.com/moses-smt/mosesdecoder/blob/master/mert/MeteorScorer.cpp
+
+using namespace std;
+using namespace lamtram;
+using namespace boost;
+using namespace boost::iostreams;
+
+#define CHILD_STDIN_READ pipefds_input[0]
+#define CHILD_STDIN_WRITE pipefds_input[1]
+#define CHILD_STDOUT_READ pipefds_output[0]
+#define CHILD_STDOUT_WRITE pipefds_output[1]
+
+EvalMeasureExtern::EvalMeasureExtern(const std::string & config, const cnn::Dict & vocab)
+                        : vocab_(vocab), run_(""), eos_(false) {
+    if(config.length() == 0) THROW_ERROR("Required for external measure: run");
+    for(const EvalMeasure::StringPair & strs : EvalMeasure::ParseConfig(config)) {
+        if(strs.first == "run") {
+            run_ = strs.second;
+        } else if(strs.first == "eos") {
+            if(strs.second == "true")
+                eos_ = true;
+            else if(strs.second == "false")
+                eos_ = false;
+            else
+                THROW_ERROR("Bad eos value: " << strs.second);
+        } else {
+            THROW_ERROR("Bad configuration string: " << config);
+        }
+    }
+    if(run_ == "") THROW_ERROR("Required for external measure: run");
+
+    // Create pipes for process communication
+    int pipe_status;
+    int pipefds_input[2];
+    int pipefds_output[2];
+    pipe_status = pipe(pipefds_input);
+    if (pipe_status == -1) {
+        THROW_ERROR("Error creating pipe");
+    }
+    pipe_status = pipe(pipefds_output);
+    if (pipe_status == -1) {
+        THROW_ERROR("Error creating pipe");
+    }
+    // Fork
+    pid_t pid;
+    pid = fork();
+    if (pid == pid_t(0)) {
+        // Child's IO
+        dup2(CHILD_STDIN_READ, 0);
+        dup2(CHILD_STDOUT_WRITE, 1);
+        close(CHILD_STDIN_WRITE);
+        close(CHILD_STDOUT_READ);
+        // Execute external command: the format is executable followed by args
+        // followed by null.  In this case, the only arg is the executable
+        // itself (conventionally passed as arg0)
+        execl(run_.c_str(), run_.c_str(), (char*) NULL);
+        THROW_ERROR("Continued after execl");
+    }
+    // Parent's IO
+    close(CHILD_STDIN_READ);
+    close(CHILD_STDOUT_WRITE);
+    // IO streams for process communication
+    to_child_buffer_.reset(new stream_buffer<file_descriptor_sink>(CHILD_STDIN_WRITE, file_descriptor_flags::close_handle));
+    from_child_buffer_.reset(new stream_buffer<file_descriptor_source>(CHILD_STDOUT_READ, file_descriptor_flags::close_handle));
+    to_child_.reset(new ostream(to_child_buffer_.get()));
+    from_child_.reset(new istream(from_child_buffer_.get()));
+}
+
+// Measure the score of the sys output according to the ref
+std::shared_ptr<EvalStats> EvalMeasureExtern::CalculateStats(const Sentence & ref, const Sentence & sys) const {
+    int offset = eos_ ? 0 : 1;
+    vector<string> sys_words;
+    for (int i = 0; i < sys.size() - offset; ++i)
+        sys_words.push_back(vocab_.convert(sys[i]));
+    vector<string> ref_words;
+    for (int i = 0; i < ref.size() - offset; ++i)
+        ref_words.push_back(vocab_.convert(ref[i]));
+    //cerr << "TO ||| " << boost::algorithm::join(sys_words, " ") << " ||| " << boost::algorithm::join(ref_words, " ") << endl;
+    *to_child_ << boost::algorithm::join(sys_words, " ") << " ||| " << boost::algorithm::join(ref_words, " ") << endl;
+    string from_line;
+    getline(*from_child_, from_line);
+    //cerr << "FROM ||| " << from_line << endl;
+    EvalStatsDataType score = lexical_cast<float>(from_line);
+    return std::shared_ptr<EvalStats>(new EvalStatsExtern(score));
+}
+
+// Read in the stats
+std::shared_ptr<EvalStats> EvalMeasureExtern::ReadStats(const std::string & line) {
+    EvalStatsPtr ret(new EvalStatsExtern(0));
+    ret->ReadStats(line);
+    return ret;
+}

--- a/src/lamtram/eval-measure-extern.h
+++ b/src/lamtram/eval-measure-extern.h
@@ -1,0 +1,64 @@
+#ifndef EVAL_MEASURE_EXTERN_H__
+#define EVAL_MEASURE_EXTERN_H__
+
+#include <lamtram/sentence.h>
+#include <lamtram/eval-measure.h>
+#include <cnn/dict.h>
+#include <boost/iostreams/device/file_descriptor.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <vector>
+
+namespace lamtram {
+
+class EvalStatsExtern : public EvalStats {
+
+public:
+
+    EvalStatsExtern(float score = 0.0) {
+        vals_.resize(1);
+        vals_[0] = score;
+    }
+    float ConvertToScore() const { return vals_[0]; }
+    EvalStatsPtr Clone() const { return EvalStatsPtr(new EvalStatsExtern(vals_[0])); }
+    virtual std::string GetIdString() const { return "Extern"; }
+
+};
+
+class EvalMeasureExtern : public EvalMeasure {
+
+public:
+
+    EvalMeasureExtern(const std::string & str, const cnn::Dict & vocab);
+
+    // Calculate the stats for a single sentence
+    virtual std::shared_ptr<EvalStats> CalculateStats(
+                const Sentence & ref,
+                const Sentence & sys) const;
+
+    // Calculate the stats for a single sentence
+    virtual EvalStatsPtr ReadStats(
+                const std::string & file);
+
+protected:
+
+    // Target vocabulary to generate sys/ref strings
+    const cnn::Dict & vocab_;
+
+    // External evaluation measure executable to run
+    std::string run_;
+
+    // Print <s> at end of sentence?  Defaults to false since most external
+    // measures aren't expecting it.
+    bool eos_;
+
+    // External measure child process communication
+    std::shared_ptr<boost::iostreams::stream_buffer<boost::iostreams::file_descriptor_sink>> to_child_buffer_;
+    std::shared_ptr<boost::iostreams::stream_buffer<boost::iostreams::file_descriptor_source>> from_child_buffer_;
+    std::shared_ptr<std::ostream> to_child_;
+    std::shared_ptr<std::istream> from_child_;
+
+};
+
+}
+
+#endif

--- a/src/lamtram/eval-measure-interp.cc
+++ b/src/lamtram/eval-measure-interp.cc
@@ -3,6 +3,8 @@
 #include <lamtram/eval-measure-loader.h>
 #include <lamtram/macros.h>
 
+#include <cnn/dict.h>
+
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -99,14 +101,14 @@ EvalStatsPtr EvalMeasureInterp::ReadStats(const std::string & line) {
     return EvalStatsPtr(new EvalStatsInterp(stats, coeffs_));
 }
 
-EvalMeasureInterp::EvalMeasureInterp(const std::string & config) {
+EvalMeasureInterp::EvalMeasureInterp(const std::string & config, const cnn::Dict & vocab) {
     vector<string> strs;
     boost::algorithm::split(strs, config, boost::is_any_of("|"));
     if(strs.size() == 0 || strs.size() % 2 != 0)
         THROW_ERROR("Bad configuration in interpreted evaluation measure: " << config);
     for(int i = 0; i < (int)strs.size(); i += 2) {
         coeffs_.push_back(boost::lexical_cast<float>(strs[i]));
-        measures_.push_back(std::shared_ptr<EvalMeasure>(EvalMeasureLoader::CreateMeasureFromString(strs[i+1])));
+        measures_.push_back(std::shared_ptr<EvalMeasure>(EvalMeasureLoader::CreateMeasureFromString(strs[i+1], vocab)));
     }
 }
 

--- a/src/lamtram/eval-measure-interp.h
+++ b/src/lamtram/eval-measure-interp.h
@@ -8,6 +8,7 @@
 
 #include <lamtram/sentence.h>
 #include <lamtram/eval-measure.h>
+#include <cnn/dict.h>
 #include <map>
 #include <vector>
 
@@ -47,7 +48,7 @@ public:
 
     EvalMeasureInterp(const std::vector<std::shared_ptr<EvalMeasure> > & measures, const std::vector<float> & coeffs) 
         : measures_(measures), coeffs_(coeffs) { }
-    EvalMeasureInterp(const std::string & str);
+    EvalMeasureInterp(const std::string & str, const cnn::Dict & vocab);
     virtual ~EvalMeasureInterp() { }
 
     // Calculate the stats for a single sentence

--- a/src/lamtram/eval-measure-loader.cc
+++ b/src/lamtram/eval-measure-loader.cc
@@ -2,17 +2,19 @@
 
 #include <lamtram/eval-measure.h>
 #include <lamtram/eval-measure-bleu.h>
+#include <lamtram/eval-measure-extern.h>
 #include <lamtram/eval-measure-ribes.h>
 #include <lamtram/eval-measure-wer.h>
 #include <lamtram/eval-measure-interp.h>
 #include <lamtram/macros.h>
+#include <cnn/dict.h>
 
 using namespace std;
 using namespace lamtram;
 
 namespace lamtram {
 
-EvalMeasure * EvalMeasureLoader::CreateMeasureFromString(const string & str) {
+EvalMeasure * EvalMeasureLoader::CreateMeasureFromString(const string & str, const cnn::Dict & vocab) {
     // Get the eval, config substr
     string eval, config;
     size_t eq = str.find(':');
@@ -21,12 +23,14 @@ EvalMeasure * EvalMeasureLoader::CreateMeasureFromString(const string & str) {
     // Create the actual measure
     if(eval == "bleu") 
         return new EvalMeasureBleu(config);
+    else if(eval == "extern")
+        return new EvalMeasureExtern(config, vocab);
     else if(eval == "ribes")
         return new EvalMeasureRibes(config);
     else if(eval == "wer")
         return new EvalMeasureWer(config);
     else if(eval == "interp")
-        return new EvalMeasureInterp(config);
+        return new EvalMeasureInterp(config, vocab);
     else
         THROW_ERROR("Unknown evaluation measure: " << eval);
     return NULL;

--- a/src/lamtram/eval-measure-loader.h
+++ b/src/lamtram/eval-measure-loader.h
@@ -1,6 +1,7 @@
 #ifndef EVAL_MEASURE_LOADER_H__
 #define EVAL_MEASURE_LOADER_H__
 
+#include <cnn/dict.h>
 #include <string>
 
 namespace lamtram {
@@ -15,7 +16,7 @@ class EvalMeasureLoader {
 
 public:
     // Create measure from string
-    static EvalMeasure * CreateMeasureFromString(const std::string & str);
+    static EvalMeasure * CreateMeasureFromString(const std::string & str, const cnn::Dict & vocab);
 
 }; // class EvalMeasureLoader
 

--- a/src/lamtram/lamtram-train.cc
+++ b/src/lamtram/lamtram-train.cc
@@ -440,7 +440,7 @@ void LamtramTrain::TrainEncDec() {
                       *vocab_src, *vocab_trg, *model, *encdec);
   } else if(crit == "minrisk") {
     // Get the evaluator
-    std::shared_ptr<EvalMeasure> eval(EvalMeasureLoader::CreateMeasureFromString(vm_["eval_meas"].as<string>()));
+    std::shared_ptr<EvalMeasure> eval(EvalMeasureLoader::CreateMeasureFromString(vm_["eval_meas"].as<string>(), *vocab_trg));
     MinRiskTraining(train_src, train_trg, train_trg_ids, dev_src, dev_trg,
                     *vocab_src, *vocab_trg, *eval, *model, *encdec);
   } else {
@@ -508,7 +508,7 @@ void LamtramTrain::TrainEncAtt() {
                       *vocab_src, *vocab_trg, *model, *encatt);
   } else if(crit == "minrisk") {
     // Get the evaluator
-    std::shared_ptr<EvalMeasure> eval(EvalMeasureLoader::CreateMeasureFromString(vm_["eval_meas"].as<string>()));
+    std::shared_ptr<EvalMeasure> eval(EvalMeasureLoader::CreateMeasureFromString(vm_["eval_meas"].as<string>(), *vocab_trg));
     MinRiskTraining(train_src, train_trg, train_trg_ids, dev_src, dev_trg,
                     *vocab_src, *vocab_trg, *eval, *model, *encatt);
   } else {


### PR DESCRIPTION
This includes two main parts: an external measure interface and a sample implementation for Meteor.

External measure: create a subprocess for a user-specified executable and outsource scoring system/reference pairs.  Lamtram sends one line at a time of "system output ||| reference translation" and reads one score line at a time.  The executable is self-contained and doesn't take any arguments.

Sample implementation: A wrapper script for Meteor is both an example and documentation for writing external metrics.  New metrics can be added to the contrib directory and used without explicit integration with the codebase.

