### PR TITLE
Instance weighting for translation model training

### DIFF
--- a/src/lamtram/encoder-attentional.h
+++ b/src/lamtram/encoder-attentional.h
@@ -126,11 +126,22 @@ public:
     ~EncoderAttentional() { }
 
     // Build the computation graph for the sentence including loss
-    template <class SentData>
-    dynet::expr::Expression BuildSentGraph(const SentData & sent_src, const SentData & sent_trg, const SentData & sent_cache,
+    dynet::expr::Expression BuildSentGraph(const Sentence & sent_src,
+                                         const Sentence & sent_trg,
+                                         const Sentence & cache_trg,
+                                         const float * weight,
                                          float samp_percent,
                                          bool train,
-                                         dynet::ComputationGraph & cg, LLStats & ll);
+                                         dynet::ComputationGraph & cg,
+                                         LLStats & ll);
+    dynet::expr::Expression BuildSentGraph(const std::vector<Sentence> & sent_src,
+                                         const std::vector<Sentence> & sent_trg,
+                                         const std::vector<Sentence> & cache_trg,
+                                         const std::vector<float> * weights,
+                                         float samp_percent,
+                                         bool train,
+                                         dynet::ComputationGraph & cg,
+                                         LLStats & ll);
 
     // Sample sentences and return an expression of the vector of probabilities
     dynet::expr::Expression SampleTrgSentences(const Sentence & sent_src,

--- a/src/lamtram/encoder-classifier.cc
+++ b/src/lamtram/encoder-classifier.cc
@@ -49,30 +49,37 @@ dynet::expr::Expression EncoderClassifier::GetEncodedState(
     return tanh(affine_transform({i_enc2cls_b_, i_enc2cls_W_, i_combined}));
 }
 
-template <class SentData, class OutputType>
-dynet::expr::Expression EncoderClassifier::BuildSentGraph(const SentData & sent_src, const OutputType & trg, const OutputType & cache,
+dynet::expr::Expression EncoderClassifier::BuildSentGraph(const Sentence & sent_src,
+                                                        const int & trg,
+                                                        const int & cache,
+                                                        const float * weight,
                                                         float samp_percent,
                                                         bool train,
-                                                        dynet::ComputationGraph & cg, LLStats & ll) const {
+                                                        dynet::ComputationGraph & cg,
+                                                        LLStats & ll) {
     if(&cg != curr_graph_)
-        THROW_ERROR("Initialized computation graph and passed comptuation graph don't match."); 
+        THROW_ERROR("Initialized computation graph and passed comptuation graph don't match.");
     // Perform encoding with each encoder
     dynet::expr::Expression classifier_in = GetEncodedState(sent_src, train, cg);
     ll.words_ += classifier_in.value().d.bd;
     return classifier_->BuildGraph(classifier_in, trg, train, cg);
 }
 
-template
-dynet::expr::Expression EncoderClassifier::BuildSentGraph<Sentence, int>(
-  const Sentence & sent_src, const int & trg, const int & cache, 
-  float samp_percent,
-  bool train, dynet::ComputationGraph & cg, LLStats & ll) const;
-template
-dynet::expr::Expression EncoderClassifier::BuildSentGraph<vector<Sentence>, vector<int> >(
-  const vector<Sentence> & sent_src, const vector<int> & trg, const vector<int> & cache,
-  float samp_percent,
-  bool train, dynet::ComputationGraph & cg, LLStats & ll) const;
-
+dynet::expr::Expression EncoderClassifier::BuildSentGraph(const std::vector<Sentence> & sent_src,
+                                                        const std::vector<int> & trg,
+                                                        const std::vector<int> & cache,
+                                                        const std::vector<float> * weights,
+                                                        float samp_percent,
+                                                        bool train,
+                                                        dynet::ComputationGraph & cg,
+                                                        LLStats & ll) {
+    if(&cg != curr_graph_)
+        THROW_ERROR("Initialized computation graph and passed comptuation graph don't match.");
+    // Perform encoding with each encoder
+    dynet::expr::Expression classifier_in = GetEncodedState(sent_src, train, cg);
+    ll.words_ += classifier_in.value().d.bd;
+    return classifier_->BuildGraph(classifier_in, trg, train, cg);
+}
 
 template <class SoftmaxOp>
 dynet::expr::Expression EncoderClassifier::Forward(const Sentence & sent_src,

--- a/src/lamtram/encoder-classifier.h
+++ b/src/lamtram/encoder-classifier.h
@@ -35,11 +35,22 @@ public:
                       const SentData & sent_src, bool train, dynet::ComputationGraph & cg) const;
 
     // Build the computation graph for the sentence including loss
-    template <class SentData, class OutData>
-    dynet::expr::Expression BuildSentGraph(const SentData & sent_src, const OutData & trg, const OutData & cache,
+    dynet::expr::Expression BuildSentGraph(const Sentence & sent_src,
+                                         const int & trg,
+                                         const int & cache,
+                                         const float * weight,
                                          float samp_percent,
                                          bool train,
-                                         dynet::ComputationGraph & cg, LLStats & ll) const;
+                                         dynet::ComputationGraph & cg,
+                                         LLStats & ll);
+    dynet::expr::Expression BuildSentGraph(const std::vector<Sentence> & sent_src,
+                                         const std::vector<int> & trg,
+                                         const std::vector<int> & cache,
+                                         const std::vector<float> * weights,
+                                         float samp_percent,
+                                         bool train,
+                                         dynet::ComputationGraph & cg,
+                                         LLStats & ll);
 
     // Calculate the probabilities from the model, or predict
     template <class SoftmaxOp>

--- a/src/lamtram/encoder-decoder.h
+++ b/src/lamtram/encoder-decoder.h
@@ -29,12 +29,22 @@ public:
     ~EncoderDecoder() { }
 
     // Build the computation graph for the sentence including loss
-    template <class SentData>
-    dynet::expr::Expression BuildSentGraph(const SentData & sent_src, const SentData & sent_trg,
-                                         const SentData & cache_trg,
+    dynet::expr::Expression BuildSentGraph(const Sentence & sent_src,
+                                         const Sentence & sent_trg,
+                                         const Sentence & cache_trg,
+                                         const float * weight,
                                          float samp_percent,
                                          bool train,
-                                         dynet::ComputationGraph & cg, LLStats & ll);
+                                         dynet::ComputationGraph & cg,
+                                         LLStats & ll);
+    dynet::expr::Expression BuildSentGraph(const std::vector<Sentence> & sent_src,
+                                         const std::vector<Sentence> & sent_trg,
+                                         const std::vector<Sentence> & cache_trg,
+                                         const std::vector<float> * weights,
+                                         float samp_percent,
+                                         bool train,
+                                         dynet::ComputationGraph & cg,
+                                         LLStats & ll);
 
     // Sample sentences and return an expression of the vector of probabilities
     dynet::expr::Expression SampleTrgSentences(const Sentence & sent_src,

--- a/src/lamtram/lamtram-train.h
+++ b/src/lamtram/lamtram-train.h
@@ -32,6 +32,7 @@ public:
     void BilingualTraining(const std::vector<Sentence> & train_src,
                            const std::vector<OutputType> & train_trg,
                            const std::vector<OutputType> & train_cache,
+                           const std::vector<float> & train_weights,
                            const std::vector<Sentence> & dev_src,
                            const std::vector<OutputType> & dev_trg,
                            const dynet::Dict & vocab_src,
@@ -59,6 +60,7 @@ public:
     // Load in the training data
     void LoadFile(const std::string filename, bool add_last, dynet::Dict & vocab, std::vector<Sentence> & sents);
     void LoadLabels(const std::string filename, dynet::Dict & vocab, std::vector<int> & labs);
+    void LoadWeights(const std::string filename, std::vector<float> & weights);
 
     void LoadBothFiles(
           const std::string filename_src, dynet::Dict & vocab_src, std::vector<Sentence> & sents_src,
@@ -73,7 +75,7 @@ protected:
     int epochs_, context_, eval_every_;
     float scheduled_samp_, dropout_;
     std::string model_in_file_, model_out_file_;
-    std::vector<std::string> train_files_trg_, train_files_src_;
+    std::vector<std::string> train_files_trg_, train_files_src_, train_files_weights_;
     std::string dev_file_trg_, dev_file_src_;
     std::string softmax_sig_;
 

--- a/src/lamtram/neural-lm.h
+++ b/src/lamtram/neural-lm.h
@@ -56,19 +56,23 @@ public:
     dynet::expr::Expression BuildSentGraph(
                                    const Sentence & sent,
                                    const Sentence & cache_ids,
+                                   const float * weight,
                                    const ExternCalculator * extern_calc,
                                    const std::vector<dynet::expr::Expression> & layer_in,
                                    float samp_percent,
                                    bool train,
-                                   dynet::ComputationGraph & cg, LLStats & ll);
+                                   dynet::ComputationGraph & cg,
+                                   LLStats & ll);
     dynet::expr::Expression BuildSentGraph(
                                    const std::vector<Sentence> & sent,
                                    const std::vector<Sentence> & cache_ids,
+                                   const std::vector<float> * weights,
                                    const ExternCalculator * extern_calc,
                                    const std::vector<dynet::expr::Expression> & layer_in,
                                    float samp_percent,
                                    bool train,
-                                   dynet::ComputationGraph & cg, LLStats & ll);
+                                   dynet::ComputationGraph & cg,
+                                   LLStats & ll);
 
     // Acquire samples from this sentence and return their log probabilities as a vector
     dynet::expr::Expression SampleTrgSentences(

--- a/src/test/test-encoder-attentional.cc
+++ b/src/test/test-encoder-attentional.cc
@@ -68,7 +68,7 @@ struct TestEncoderAttentional {
     for(size_t i = 0; i < 100; ++i) {
       dynet::ComputationGraph cg;
       encatt->NewGraph(cg);
-      dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, sent_trg_, cache_, 0.f, false, cg, train_stat);
+      dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, sent_trg_, cache_, nullptr, 0.f, false, cg, train_stat);
       cg.forward(loss_expr);
       cg.backward(loss_expr);
       sgd.update(0.1);
@@ -90,7 +90,7 @@ struct TestEncoderAttentional {
     {
       dynet::ComputationGraph cg;
       encatt->NewGraph(cg);
-      dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, sent_trg_, cache_, 0.f, false, cg, train_stat);
+      dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, sent_trg_, cache_, nullptr, 0.f, false, cg, train_stat);
       train_stat.loss_ += as_scalar(cg.incremental_forward(loss_expr));
     }
     vector<float> test_wordll;
@@ -117,7 +117,7 @@ struct TestEncoderAttentional {
       LLStats train_stat(vocab_trg_->size());
       dynet::ComputationGraph cg;
       encatt->NewGraph(cg);
-      dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, decode_sent, cache_, 0.f, false, cg, train_stat);
+      dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, decode_sent, cache_, nullptr, 0.f, false, cg, train_stat);
       train_ll = -as_scalar(cg.incremental_forward(loss_expr));
     }
     BOOST_CHECK_CLOSE(train_ll, decode_ll, 0.01);
@@ -184,12 +184,12 @@ BOOST_AUTO_TEST_CASE(TestLLBatchScores) {
   // Do unbatched calculation
   {
     dynet::ComputationGraph cg; encatt->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, sent_trg_, cache_, 0.f, false, cg, unbatch_stat);
+    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, sent_trg_, cache_, nullptr, 0.f, false, cg, unbatch_stat);
     unbatch_stat.loss_ += as_scalar(cg.incremental_forward(loss_expr));
   }
   {
     dynet::ComputationGraph cg; encatt->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src2_, sent_trg2_, cache_, 0.f, false, cg, unbatch_stat);
+    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src2_, sent_trg2_, cache_, nullptr, 0.f, false, cg, unbatch_stat);
     unbatch_stat.loss_ += as_scalar(cg.incremental_forward(loss_expr));
   }
   // Do batched calculation
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(TestLLBatchScores) {
     std::vector<Sentence> batch_trg(2); batch_trg[0] = sent_trg_; batch_trg[1] = sent_trg2_;
     std::vector<Sentence> batch_cache(2); batch_cache[0] = cache_; batch_cache[1] = cache_;
     dynet::ComputationGraph cg; encatt->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(batch_src, batch_trg, batch_cache, 0.f, false, cg, batch_stat);
+    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(batch_src, batch_trg, batch_cache, nullptr, 0.f, false, cg, batch_stat);
     batch_stat.loss_ += as_scalar(cg.incremental_forward(loss_expr));
   }
   BOOST_CHECK_CLOSE(unbatch_stat.CalcPPL(), batch_stat.CalcPPL(), 0.5);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(TestBeamDecodingScores) {
     LLStats train_stat(vocab_trg_->size());
     dynet::ComputationGraph cg;
     encatt->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, decode_sent, cache_, 0.f, false, cg, train_stat);
+    dynet::expr::Expression loss_expr = encatt->BuildSentGraph(sent_src_, decode_sent, cache_, nullptr, 0.f, false, cg, train_stat);
     train_ll = -as_scalar(cg.incremental_forward(loss_expr));
   }
   BOOST_CHECK_CLOSE(train_ll, decode_ll, 0.01);

--- a/src/test/test-encoder-decoder.cc
+++ b/src/test/test-encoder-decoder.cc
@@ -39,7 +39,7 @@ struct TestEncoderDecoder {
     for(size_t i = 0; i < 100; ++i) {
       dynet::ComputationGraph cg;
       encdec_->NewGraph(cg);
-      dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, sent_trg_, cache_, 0.f, false, cg, train_stat);
+      dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, sent_trg_, cache_, nullptr, 0.f, false, cg, train_stat);
       cg.forward(loss_expr);
       cg.backward(loss_expr);
       sgd.update(0.1);
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(TestLLScores) {
   {
     dynet::ComputationGraph cg;
     encdec_->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, sent_trg_, cache_, 0.f, false, cg, train_stat);
+    dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, sent_trg_, cache_, nullptr, 0.f, false, cg, train_stat);
     train_stat.loss_ += as_scalar(cg.incremental_forward(loss_expr));
   }
   vector<float> test_wordll;
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(TestDecodingScores) {
     LLStats train_stat(vocab_trg_->size());
     dynet::ComputationGraph cg;
     encdec_->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, decode_sent, cache_, 0.f, false, cg, train_stat);
+    dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, decode_sent, cache_, nullptr, 0.f, false, cg, train_stat);
     train_ll = -as_scalar(cg.incremental_forward(loss_expr));
   }
   BOOST_CHECK_CLOSE(train_ll, decode_ll, 0.01);
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(TestBeamDecodingScores) {
     LLStats train_stat(vocab_trg_->size());
     dynet::ComputationGraph cg;
     encdec_->NewGraph(cg);
-    dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, decode_sent, cache_, 0.f, false, cg, train_stat);
+    dynet::expr::Expression loss_expr = encdec_->BuildSentGraph(sent_src_, decode_sent, cache_, nullptr, 0.f, false, cg, train_stat);
     train_ll = -as_scalar(cg.incremental_forward(loss_expr));
   }
   BOOST_CHECK_CLOSE(train_ll, decode_ll, 0.01);

--- a/src/test/test-neural-lm.cc
+++ b/src/test/test-neural-lm.cc
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(TestDecodingScores) {
   {
     dynet::ComputationGraph cg;
     lmptr->NewGraph(cg);
-    dynet::expr::Expression loss_expr = lmptr->BuildSentGraph(sent_trg_, cache_, nullptr, layer_in, 0.f, false, cg, train_stat);
+    dynet::expr::Expression loss_expr = lmptr->BuildSentGraph(sent_trg_, cache_, nullptr, nullptr, layer_in, 0.f, false, cg, train_stat);
     train_stat.loss_ += as_scalar(cg.incremental_forward(loss_expr));
   }
   vector<float> test_wordll;


### PR DESCRIPTION
Allows specifying a --train_weights file for encdec and encatt models that supplies one weight per line for sentences in the training data.  During ML training, loss for examples from each sentence are scaled by that sentence's weight.  If no weights are specified, weight vectors are either empty or null pointers and loss calculation is unaffected.  How to determine useful training data weights is an open question.