### PR TITLE
Full Docker support for Lamtram

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ on building strong neural machine translation systems.
 Install/Citation
 ----------------
 
+(To run Lamtram easily using Docker, see docker/README.md.  To install manually, read on.)
+
 First, in terms of standard libraries, you must have autotools, libtool, and Boost. If
 you are on Ubuntu/Debian linux, you can install them below:
 

--- a/docker/Dockerfile.lamtram
+++ b/docker/Dockerfile.lamtram
@@ -1,0 +1,12 @@
+FROM lamtram-deps:latest
+
+# Lamtram (this version)
+COPY . /opt/lamtram
+RUN cd /opt/lamtram && \
+        export LDFLAGS="-L/usr/local/cuda/lib64" && \
+        autoreconf -i && \
+        ./configure --with-dynet=/opt/dynet --with-eigen=/opt/eigen --with-cuda=/usr/local/cuda && \
+        make -j16 install
+RUN cp /opt/lamtram/script/* /usr/local/bin
+ENV LD_LIBRARY_PATH /usr/local/lib:${LD_LIBRARY_PATH}
+WORKDIR /work

--- a/docker/Dockerfile.lamtram-deps
+++ b/docker/Dockerfile.lamtram-deps
@@ -1,0 +1,50 @@
+FROM nvidia/cuda:7.5-cudnn4-devel
+
+# Add Tini so signals are forwarded properly (like ctrl+c)
+ENV TINI_VERSION v0.10.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+# Build dependencies
+RUN apt-get update && apt-get install -y wget git mercurial libgoogle-perftools-dev libsparsehash-dev libboost-all-dev autoconf libtool openjdk-7-jdk
+RUN apt-get build-dep -y cmake
+
+# CMake 3.6.2 (version that ships with Ubuntu 14.04 doesn't fully support CUDA)
+RUN cd /opt && \
+        wget "https://cmake.org/files/v3.6/cmake-3.6.2.tar.gz" && \
+        tar xf cmake-3.6.2.tar.gz && \
+        cd cmake-3.6.2 && \
+        ./configure && \
+        make -j16 install
+
+# fast_align
+ENV FAST_ALIGN_VERSION 7c2bbca3d5d61ba4b0f634f098c4fcf63c1373e1
+RUN cd /opt && \
+        git clone https://github.com/clab/fast_align.git && \
+        cd fast_align && \
+        git checkout ${FAST_ALIGN_VERSION} && \
+        mkdir build && \
+        cd build && \
+        cmake .. && \
+        make -j16
+RUN cd /opt/fast_align/build && \
+        cp atools fast_align force_align.py /usr/local/bin
+
+# Eigen, update version as needed
+ENV EIGEN_VERSION b541d80aa4fd
+RUN cd /opt && \
+        hg clone https://bitbucket.org/eigen/eigen/ && \
+        cd eigen && \
+        hg update -r ${EIGEN_VERSION}
+
+# DyNet, update version as needed
+ENV DYNET_VERSION 880fa9fa9e132fb2beed7ae617db7cfe1bcd572c
+RUN cd /opt && \
+        git clone https://github.com/clab/dynet.git && \
+        cd dynet && \
+        git checkout ${DYNET_VERSION} && \
+        mkdir build && \
+        cd build && \
+        cmake .. -DEIGEN3_INCLUDE_DIR=/opt/eigen -DBACKEND=cuda && \
+        make -j16 install

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,55 @@
+Running Lamtram via Docker
+==========================
+
+[Docker](https://www.docker.com/) makes running software with layers of dependencies significantly easier, especially in non-standard environments like research clusters.  To get started with Docker on GPUs, install the following:
+* CUDA (7.5 or later): [download page](https://developer.nvidia.com/cuda-downloads)
+* nvidia-docker: [github repository](https://github.com/NVIDIA/nvidia-docker)
+
+Software can then be built automatically and deterministically in Docker containers.
+
+Quick Start
+-----------
+
+Once CUDA and nvidia-docker are installed, run:
+
+    ./docker/build
+
+Then run:
+
+    ./docker/run lamtram-train --help
+
+Other programs and scripts are also on the default path.  If you make changes to Lamtram, simply re-run the build script to recompile/rebuild.
+
+For more details on what Docker is doing, read on.
+
+Building the Lamtram Image
+--------------------------
+
+To build a Docker image of the current commit of Lamtram, just run the build script:
+
+    ./docker/build
+
+This will start a new container based on Ubuntu Linux with CUDA and download/build all of Lamtram's dependencies.  Then the current version of Lamtram (the one in this checkout) will be copied into the container and built.
+
+The container will be saved as an image named "lamtram" (dependencies are cached as "lamtram-deps" for future builds).  You can change the name by editing the file `docker/config`.  You can also edit properties of the build in `docker/Dockerfile.lamtram-deps` and `docker/Dockerfile.lamtram`.  For instance, if you make changes to Lamtram that require a newer version of DyNet, you can update `DYNET_VERSION`.
+
+To see current Docker images available on your system, you can run `docker images` which will return something like this:
+
+    REPOSITORY          TAG           IMAGE ID            CREATED            SIZE
+    lamtram             latest        d325acb19524        3 hours ago        3.569 GB
+    lamtram-deps        latest        7a113876af1f        3 hours ago        3.262 GB
+
+You can remove images with `docker rmi`:
+
+    docker rmi -f lamtram:latest
+
+See the [Docker documentation](https://docs.docker.com/engine/reference/commandline/rmi/) for more information on managing images.
+
+Running Lamtram via Docker
+--------------------------
+
+Once the image is built, you can run Lamtram using the run script:
+
+    ./docker/run lamtram-train --help
+
+Lamtram programs (`lamtram`, `lamtram-train`), scripts (`convert-cond.pl`, `unk-single.pl`), and support programs (`fast_align`) are all available on the default path.  Docker containers are isolated from the host operating system, so only specific volumes (directories) are accessible.  By default, the run script mounts the current working directory and anything in `VOLUME_PATHS` (edit in the script to fit your setup).  Otherwise, programs can be run normally.  To run any example in the Lamtram documentation, simply add `/path/to/lamtram/docker/run` before the command.

--- a/docker/build
+++ b/docker/build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+LAMTRAM_DIR="$(dirname $(dirname $(readlink -f $0)))"
+
+REPOSITORY="$(cat $(dirname $0)/config)"
+
+# Use image name from "config", use Dockerfile in this directory, use lamtram
+# root as context root
+
+# Dependencies are versioned, so they can be cached.  Lamtram is not versioned,
+# so make sure to always update to current version on build.
+nvidia-docker build -t $REPOSITORY-deps -f $LAMTRAM_DIR/docker/Dockerfile.lamtram-deps $LAMTRAM_DIR
+nvidia-docker build --no-cache -t $REPOSITORY -f $LAMTRAM_DIR/docker/Dockerfile.lamtram $LAMTRAM_DIR

--- a/docker/config
+++ b/docker/config
@@ -1,0 +1,1 @@
+lamtram

--- a/docker/run
+++ b/docker/run
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Volumes to be made visible to docker (in addition to current working
+# directory).  Examples can be /path/to/dir or /path/to/*
+VOLUME_PATHS=""
+
+# Use image name from "config"
+REPOSITORY="$(cat $(dirname $0)/config)"
+
+# Pass through environment variable telling CUDA which GPU to use (if present)
+ENV=""
+if [[ $CUDA_VISIBLE_DEVICES != "" ]]; then
+  ENV="$ENV -e CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES"
+fi
+
+# Mount any storage volumes Docker will need
+VOL=$(echo $VOLUME_PATHS |sed -re 's/(\/[^ ]+)/-v \1:\1/g')
+
+# nvidia-docker: automatically make GPUs visible to Docker container
+# run -i: run interactively (stdio)
+# -u ...: run as current user
+# -v ...: mount current working directory in container
+# $VOL: volumes to mount
+# $ENV: environment variables to populate
+# $REPOSITORY:$TAG use requested image
+# $@: run command passed as args
+nvidia-docker run -i -u $(id -u):$(id -g) -v $(readlink -f $(pwd)):/work $VOL $ENV $REPOSITORY $@


### PR DESCRIPTION
The self-contained docker directory contains scripts for building and running Lamtram using Docker.  This reduces Lamtram's dependencies to just CUDA and nvidia-docker.  The Docker image builds deterministically by simply running `./docker/build`.