### PR TITLE
"Kickout" and early stopping for translation model training

### DIFF
--- a/src/lamtram/lamtram-train.h
+++ b/src/lamtram/lamtram-train.h
@@ -33,6 +33,7 @@ public:
                            const std::vector<OutputType> & train_trg,
                            const std::vector<OutputType> & train_cache,
                            const std::vector<float> & train_weights,
+                           const std::vector<float> & train_kickout_keep,
                            const std::vector<Sentence> & dev_src,
                            const std::vector<OutputType> & dev_trg,
                            const dynet::Dict & vocab_src,
@@ -75,7 +76,7 @@ protected:
     int epochs_, context_, eval_every_;
     float scheduled_samp_, dropout_;
     std::string model_in_file_, model_out_file_;
-    std::vector<std::string> train_files_trg_, train_files_src_, train_files_weights_;
+    std::vector<std::string> train_files_trg_, train_files_src_, train_files_weights_, train_files_kickout_keep_;
     std::string dev_file_trg_, dev_file_src_;
     std::string softmax_sig_;
 


### PR DESCRIPTION
This adds an option to "kick out" (exclude) training instances each epoch according to a user-specified file of rates.  At the start of each epoch, each sentence is considered for exclusion.  A keep rate of 1.0 guarantees inclusion while a rate of 0.2 would only have a 20% chance of inclusion.  After kickout is applied, minibatches for the epoch are created and shuffled.  Since exclusion is random subject to the rates, different epochs will have different subsets of the data.

One obvious use of kickout is to conduct oversampling as in Google's recent paper.  Doing this by including many instances of the minority data would lead to all instances landing in the same minibatch, which is probably not desirable.  Doing this by trimming down the majority data in advance would make hard exclusion decisions, which is also probably not desirable.  Using kickout to have shorter epochs that always include all minority data and a randomly sampled subset of majority data gets around these issues.

I also added a very basic option for early stopping, which people may or may not find useful, but it was only a few lines of code.